### PR TITLE
Bump MSTest.TestAdapter and MSTest.TestFramework (#104)

### DIFF
--- a/src/tests/IntegrationTests/ElevenLabs.IntegrationTests.csproj
+++ b/src/tests/IntegrationTests/ElevenLabs.IntegrationTests.csproj
@@ -10,8 +10,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.9.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
     <PackageReference Include="FluentAssertions" Version="8.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Bumps MSTest.TestAdapter from 3.9.0 to 3.9.1
Bumps MSTest.TestFramework from 3.9.0 to 3.9.1

---
updated-dependencies:
- dependency-name: Microsoft.NET.ILLink.Tasks dependency-version: 8.0.16 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: Microsoft.NET.ILLink.Tasks dependency-version: 8.0.16 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: MSTest.TestAdapter dependency-version: 3.9.1 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: MSTest.TestFramework dependency-version: 3.9.1 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: System.Text.Json dependency-version: 9.0.5 dependency-type: direct:production update-type: version-update:semver-major ...